### PR TITLE
Fix to enable compilation with clang and gcc other than Visual C++.

### DIFF
--- a/tools/driver/meta_cc1_main.cpp
+++ b/tools/driver/meta_cc1_main.cpp
@@ -115,14 +115,14 @@ public:
 
 	bool TraverseMetaGeneratedIdentifier(const IdentifierInfo *II) {
 		assert(II->isMetaGenerated());
-		return getDerived().TraverseStmt(II->getFETokenInfo<Expr>());
+		return Base::getDerived().TraverseStmt(II->getFETokenInfo<Expr>());
 	}
 protected:
 	bool TryTraverseMetaGeneratedIdentifier(const IdentifierInfo *II) {
 		bool result = true;
 		if (II && II->isMetaGenerated() && processed.find(II) == processed.end()) {
 			processed.insert(II);
-			result = getDerived().TraverseMetaGeneratedIdentifier(II);
+			result = Base::getDerived().TraverseMetaGeneratedIdentifier(II);
 		}
 		return result;
 	}
@@ -352,7 +352,14 @@ private:
 
 StageResultRewriter::Inlines StageResultRewriter::inlines;
 
-#define META_API __declspec(dllexport)
+#ifdef _MSC_VER
+#   define META_API __declspec(dllexport)
+#elif defined(__GNUC__)
+#   define META_API __attribute__((visibility("default")))
+#else
+#   define META_API
+#   pragma warning Unknown dynamic link semantics.
+#endif
 
 META_API void __meta_inline(void* ast) {
 	StageResultRewriter::AddInline((QuotedElements*) ast);


### PR DESCRIPTION
* In Visual C++ 15.2 earlier, Two-phase name lookup is not implemented, and it is disabled by default in 15.3 and later (FYI: https://devblogs.microsoft.com/cppblog/two-phase-name-lookup-support-comes-to-msvc/), so Visual C++ may be able to compile without the modification `Base::`. However, this code is invalid in standard C++ (gcc and clang).
* `__declspec` is a Visual C++-specific extended attribute syntax.